### PR TITLE
refactor: rename task inputs to generic upstream-output

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ stage "execution" {
       }
     }
     options = {
-      execution_binary = "compilation-output/main"
+      execution_binary = "upstream-output/main"
       execution_flags  = "{{ .args }}"
       input_path       = "assignment-assets/{{ .code }}/input.txt"
       output_path      = "output.txt"
@@ -130,7 +130,7 @@ stage "testing" {
     }
     
     options = {
-      input_path = "execution-output/output.txt"
+      input_path = "upstream-output/output.txt"
       expected_path = "assignment-assets/{{ .code }}/expected.txt"
       score = "{{ .score }}"     # Uses the scenario's score parameter
       timeout = "{{ .timeout }}"  # Uses the scenario's timeout parameter
@@ -167,7 +167,7 @@ The templating process:
 ## Path Resolution
 
 **Important**: All paths in task parameters are relative to their respective resources:
-- Input paths are relative to the input resource root (e.g., `submission/`, `assignment-assets/`, `compilation-output/`)
+- Input paths are relative to the input resource root (e.g., `submission/`, `assignment-assets/`, `upstream-output/`)
 - Output paths are now simple filenames or relative paths (e.g., `main`, `output.txt`, `stderr.txt`)
 - Ghost automatically creates parent directories for output files
 - Output files are uploaded directly to the configured storage location via ghost
@@ -204,9 +204,10 @@ run:
 2. **assignment-assets**: Test cases, inputs, expected outputs (from MinIO)
 3. **toolkit**: This repository (cloned via Git)
 4. **ghost**: Command runner (downloaded from GitHub releases)
-5. **compilation-output**: Results from compilation stage
-6. **execution-output**: Results from execution stage (per scenario)
-7. **testing-output**: Results from testing stage (per scenario)
+5. **upstream-output**: Generic input from previous pipeline stage (optional)
+6. **compilation-output**: Results from compilation stage (task output)
+7. **execution-output**: Results from execution stage per scenario (task output)
+8. **testing-output**: Results from testing stage per scenario (task output)
 
 ## Input/Output Resources by Task Type
 
@@ -228,7 +229,7 @@ output_binary: main  # Output binary relative to output directory
 ### Execution Tasks
 **Inputs:**
 - `submission`: Original source code (if needed)
-- `compilation-output`: Compiled binaries from compilation stage
+- `upstream-output`: Output from previous stage (optional, typically compiled binaries)
 - `assignment-assets`: Test input files
 - `ghost`: Command runner binary
 
@@ -237,7 +238,7 @@ output_binary: main  # Output binary relative to output directory
 
 **Common Path Examples:**
 ```yaml
-execution_binary: compilation-output/main           # Reads from compilation-output/main
+execution_binary: upstream-output/main              # Reads from upstream-output/main
 input_path: assignment-assets/{{ .code }}/input.txt # Input file for test case
 output_path: output.txt                             # Stdout saved relative to output directory
 stderr_path: stderr.txt                             # Stderr saved relative to output directory
@@ -247,7 +248,7 @@ stderr_path: stderr.txt                             # Stderr saved relative to o
 
 ### Testing Tasks
 **Inputs:**
-- `execution-output`: Actual program outputs from execution stage
+- `upstream-output`: Output from previous stage (optional, typically execution outputs)
 - `assignment-assets`: Expected output files
 - `ghost`: Command runner binary
 
@@ -256,7 +257,7 @@ stderr_path: stderr.txt                             # Stderr saved relative to o
 
 **Common Path Examples:**
 ```yaml
-input_path: execution-output/output.txt                  # Actual output from scenario's execution
+input_path: upstream-output/output.txt                   # Actual output from previous stage
 expected_path: assignment-assets/{{ .code }}/expected.txt # Expected output
 output_path: diff.txt                                    # Diff results saved relative to output directory
 ```

--- a/compilation/gcc.yaml
+++ b/compilation/gcc.yaml
@@ -6,6 +6,8 @@ image_resource:
     tag: ((version))
 inputs:
   - name: submission
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:

--- a/compilation/java.yaml
+++ b/compilation/java.yaml
@@ -6,6 +6,8 @@ image_resource:
     tag: ((version))-((variant))
 inputs:
   - name: submission
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:

--- a/dev/test-configs/execution/java.test.yaml
+++ b/dev/test-configs/execution/java.test.yaml
@@ -74,30 +74,30 @@ preparation:
     repository: openjdk
     tag: 17-jdk
   outputs:
-    - compilation-output
+    - upstream-output
   script: |
     echo "=== Prepare Step: Compiling Java code ==="
-    
+
     # Create compilation output directory
-    mkdir -p compilation-output
-    
+    mkdir -p upstream-output
+
     # Compile Java source files
     echo "Compiling Java files..."
-    javac submission/*.java -d compilation-output/
+    javac submission/*.java -d upstream-output/
     
     # Create executable JAR file
     echo "Creating JAR file..."
-    cd compilation-output
+    cd upstream-output
     jar cfe app.jar InputReader InputReader.class
     cd ..
-    
+
     # List the prepared files
     echo "Prepared files:"
-    ls -la compilation-output/
+    ls -la upstream-output/
 
 task_parameters:
   execution_type: "jar"
-  execution_target: "compilation-output/app.jar"
+  execution_target: "upstream-output/app.jar"
   classpath: ""
   java_flags: ""
   execution_flags: ""

--- a/dev/test-configs/execution/stdio-with-sanitizer.test.yaml
+++ b/dev/test-configs/execution/stdio-with-sanitizer.test.yaml
@@ -10,7 +10,7 @@ preparation:
     repository: gcc
     tag: latest
   outputs:
-    - compilation-output
+    - upstream-output
   script: |
     echo "🔨 Compiling with AddressSanitizer..."
     
@@ -59,19 +59,19 @@ preparation:
     
     # Compile with AddressSanitizer
     gcc -g -fsanitize=address -fno-omit-frame-pointer -O1 \
-        /tmp/memory_test.c -o compilation-output/memory_test
-    
-    if [ -f compilation-output/memory_test ]; then
+        /tmp/memory_test.c -o upstream-output/memory_test
+
+    if [ -f upstream-output/memory_test ]; then
         echo "✅ Binary compiled with ASAN"
-        echo "Binary size: $(du -h compilation-output/memory_test | cut -f1)"
-        
+        echo "Binary size: $(du -h upstream-output/memory_test | cut -f1)"
+
         # Check for ASAN symbols
-        if strings compilation-output/memory_test | grep -q "__asan"; then
+        if strings upstream-output/memory_test | grep -q "__asan"; then
             echo "✅ ASAN symbols found in binary"
         fi
-        
+
         # Make it executable
-        chmod +x compilation-output/memory_test
+        chmod +x upstream-output/memory_test
     else
         echo "❌ Compilation failed"
         exit 1
@@ -88,7 +88,7 @@ mock_resources:
         Test input for ASAN binary
 
 task_parameters:
-  execution_binary: "compilation-output/memory_test"
+  execution_binary: "upstream-output/memory_test"
   execution_flags: "arg1 arg2"
   input_path: "assignment-assets/input.txt"
   output_path: "output.txt"
@@ -173,11 +173,11 @@ variants:
         EOF
         
         gcc -g -fsanitize=address -fno-omit-frame-pointer -O1 \
-            /tmp/leak_test.c -o compilation-output/leak_test
-        
-        chmod +x compilation-output/leak_test
+            /tmp/leak_test.c -o upstream-output/leak_test
+
+        chmod +x upstream-output/leak_test
     task_parameters:
-      execution_binary: "compilation-output/leak_test"
+      execution_binary: "upstream-output/leak_test"
       execution_flags: ""
     verification:
       script: |
@@ -223,11 +223,11 @@ variants:
         EOF
         
         gcc -g -fsanitize=address -fno-omit-frame-pointer -O1 \
-            /tmp/overflow_test.c -o compilation-output/overflow_test
-        
-        chmod +x compilation-output/overflow_test
+            /tmp/overflow_test.c -o upstream-output/overflow_test
+
+        chmod +x upstream-output/overflow_test
     task_parameters:
-      execution_binary: "compilation-output/overflow_test"
+      execution_binary: "upstream-output/overflow_test"
       execution_flags: ""
     verification:
       script: |
@@ -283,7 +283,8 @@ variants:
                 tag: latest
             inputs:
               - name: submission
-              - name: compilation-output
+              - name: upstream-output
+                optional: true
               - name: assignment-assets
               - name: ghost
             outputs:

--- a/execution/java.schema.yaml
+++ b/execution/java.schema.yaml
@@ -10,7 +10,7 @@ parameters:
   - name: execution_target
     type: string
     description: JAR file path or main class name to execute
-    default: compilation-output/app.jar
+    default: upstream-output/app.jar
     example: Main
   - name: classpath
     type: string

--- a/execution/java.yaml
+++ b/execution/java.yaml
@@ -7,7 +7,8 @@ image_resource:
     tag: ((version))-((variant))
 inputs:
   - name: submission
-  - name: compilation-output
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:
@@ -39,9 +40,9 @@ run:
         JAVA_CMD="java ${JAVA_FLAGS} -jar ${EXECUTION_TARGET}"
       else
         # For class execution, build classpath
-        FULL_CLASSPATH="compilation-output"
+        FULL_CLASSPATH="upstream-output"
         if [ -n "${CLASSPATH}" ]; then
-          FULL_CLASSPATH="${CLASSPATH}:compilation-output"
+          FULL_CLASSPATH="${CLASSPATH}:upstream-output"
         fi
         JAVA_CMD="java ${JAVA_FLAGS} -cp ${FULL_CLASSPATH} ${EXECUTION_TARGET}"
       fi

--- a/execution/python.yaml
+++ b/execution/python.yaml
@@ -8,11 +8,11 @@ image_resource:
     tag: ((version))-((variant))
 
 inputs:
-  - name: ghost
   - name: submission
   - name: upstream-output
     optional: true
   - name: assignment-assets
+  - name: ghost
 
 outputs:
   - name: execution-output

--- a/execution/python.yaml
+++ b/execution/python.yaml
@@ -10,6 +10,8 @@ image_resource:
 inputs:
   - name: ghost
   - name: submission
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
 
 outputs:

--- a/execution/stdio-sanitizer.schema.yaml
+++ b/execution/stdio-sanitizer.schema.yaml
@@ -5,8 +5,8 @@ parameters:
   - name: execution_binary
     type: string
     description: Path to the binary to execute (relative to workspace)
-    default: compilation-output/main
-    example: compilation-output/program
+    default: upstream-output/main
+    example: upstream-output/program
   - name: execution_flags
     type: string
     description: Command line arguments to pass to the binary

--- a/execution/stdio-sanitizer.yaml
+++ b/execution/stdio-sanitizer.yaml
@@ -8,7 +8,8 @@ image_resource:
     tag: ((tag))
 inputs:
   - name: submission
-  - name: compilation-output
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:

--- a/execution/stdio.schema.yaml
+++ b/execution/stdio.schema.yaml
@@ -5,8 +5,8 @@ parameters:
   - name: execution_binary
     type: string
     description: Path to binary including resource name
-    default: compilation-output/main
-    example: compilation-output/main
+    default: upstream-output/main
+    example: upstream-output/main
   - name: execution_flags
     type: string
     description: Command line arguments passed to the binary

--- a/execution/stdio.yaml
+++ b/execution/stdio.yaml
@@ -6,7 +6,8 @@ image_resource:
     repository: busybox
 inputs:
   - name: submission
-  - name: compilation-output
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:

--- a/testing/diff.schema.yaml
+++ b/testing/diff.schema.yaml
@@ -5,8 +5,8 @@ parameters:
   - name: input_path
     type: string
     description: Path to actual output file
-    default: execution-output/output.txt
-    example: execution-output/output.txt
+    default: upstream-output/output.txt
+    example: upstream-output/output.txt
   - name: expected_path
     type: string
     description: Path to expected output file

--- a/testing/diff.yaml
+++ b/testing/diff.yaml
@@ -4,6 +4,7 @@ image_resource:
   source:
     repository: busybox
 inputs:
+  - name: submission
   - name: upstream-output
     optional: true
   - name: assignment-assets

--- a/testing/diff.yaml
+++ b/testing/diff.yaml
@@ -4,7 +4,8 @@ image_resource:
   source:
     repository: busybox
 inputs:
-  - name: execution-output
+  - name: upstream-output
+    optional: true
   - name: assignment-assets
   - name: ghost
 outputs:


### PR DESCRIPTION
Replace hardcoded stage-specific input names (compilation-output, execution-output) with a generic upstream-output input to enable flexible pipeline composition.

- Add optional upstream-output input to all task categories
- Update schema defaults to use upstream-output paths
- Update test configurations and documentation
- Output names remain unchanged (compilation-output, execution-output)
- Pipelines use input_mapping to connect stages