### PR TITLE
Implement architecture detection for ghost binary across execution tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,12 @@ fly -t <target> execute -c <task-file>.yaml \
 
 - Use appropriate Docker images for the language/tool
 - Include ghost as input when executing commands
-- Set executable permissions: `chmod +x ghost/ghost-linux-amd64`
-- Use ghost path: `./ghost/ghost-linux-amd64`
+- Use architecture detection for ghost binary:
+  ```bash
+  GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+  GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+  chmod +x "$GHOST_BIN"
+  ```
 - Handle errors gracefully
 - Create output directories as needed
 - Follow existing naming conventions

--- a/compilation/gcc.yaml
+++ b/compilation/gcc.yaml
@@ -23,8 +23,11 @@ run:
   args:
     - '-c'
     - |
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
 
       # Determine compiler based on language
       if [ "${LANGUAGE}" = "cpp" ] || [ "${LANGUAGE}" = "c++" ]; then
@@ -34,7 +37,7 @@ run:
       fi
 
       # Compile with ghost
-      ./ghost/ghost-linux-amd64 run --verbose \
+      "$GHOST_BIN" run --verbose \
         -i /dev/null \
         -o compile.log \
         -e compile.err \

--- a/compilation/java.yaml
+++ b/compilation/java.yaml
@@ -27,8 +27,11 @@ run:
     - |
       set -e
       
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
       
       # Setup classpath if provided
       FULL_CLASSPATH="."
@@ -66,7 +69,7 @@ run:
         mkdir -p compilation-output/classes
         
         # Compile and create JAR with ghost tracking
-        ./ghost/ghost-linux-amd64 run --verbose \
+        "$GHOST_BIN" run --verbose \
           -i /dev/null \
           -o compile.log \
           -e compile.err \
@@ -99,7 +102,7 @@ run:
         echo "Compiling Java files to .class files"
         
         # Just compile to .class files with ghost tracking
-        ./ghost/ghost-linux-amd64 run --verbose \
+        "$GHOST_BIN" run --verbose \
           -i /dev/null \
           -o compile.log \
           -e compile.err \

--- a/dev/test-configs/execution/stdio-with-sanitizer.test.yaml
+++ b/dev/test-configs/execution/stdio-with-sanitizer.test.yaml
@@ -301,8 +301,12 @@ variants:
               args:
                 - -c
                 - |
-                  chmod +x ghost/ghost-linux-amd64
-                  ./ghost/ghost-linux-amd64 run --verbose \
+                  # Detect architecture and set ghost binary path
+                  GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+                  GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+                  chmod +x "$GHOST_BIN"
+                  
+                  "$GHOST_BIN" run --verbose \
                     -i "${INPUT_PATH}" \
                     -o "execution-output/${OUTPUT_PATH}:${OUTPUT_PATH}" \
                     -e "execution-output/${STDERR_PATH}:${STDERR_PATH}" \

--- a/execution/java.yaml
+++ b/execution/java.yaml
@@ -30,8 +30,11 @@ run:
     - |
       set -e
       
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
       
       # Build classpath
       FULL_CLASSPATH=""
@@ -52,7 +55,7 @@ run:
       echo "Input: ${INPUT_PATH}"
       
       # Execute with ghost for stdio capture and upload
-      ./ghost/ghost-linux-amd64 run --verbose \
+      "$GHOST_BIN" run --verbose \
         -i "${INPUT_PATH}" \
         -o "execution-output/${OUTPUT_PATH}:${OUTPUT_PATH}" \
         -e "execution-output/${STDERR_PATH}:${STDERR_PATH}" \

--- a/execution/python.yaml
+++ b/execution/python.yaml
@@ -37,8 +37,11 @@ run:
     - |
       set -e
       
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
       
       # Set up Python path if specified
       if [ -n "${PYTHONPATH}" ]; then
@@ -90,7 +93,7 @@ run:
       echo "📂 PYTHONPATH: ${PYTHONPATH}"
       
       # Build ghost command with input redirection (required by ghost)
-      GHOST_CMD="./ghost/ghost-linux-amd64 run --verbose"
+      GHOST_CMD="$GHOST_BIN run --verbose"
       
       # Set input file - use specified file or /dev/null if none
       if [ -n "${INPUT_PATH}" ] && [ -f "${INPUT_PATH}" ]; then

--- a/execution/stdio-sanitizer.yaml
+++ b/execution/stdio-sanitizer.yaml
@@ -30,8 +30,11 @@ run:
   args:
     - -c
     - |
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
       
       # Set sanitizer options if provided
       if [ -n "${ASAN_OPTIONS}" ]; then
@@ -50,7 +53,7 @@ run:
       fi
       
       # Execute with ghost
-      ./ghost/ghost-linux-amd64 run --verbose \
+      "$GHOST_BIN" run --verbose \
         -i "${INPUT_PATH}" \
         -o "execution-output/${OUTPUT_PATH}:${OUTPUT_PATH}" \
         -e "execution-output/${STDERR_PATH}:${STDERR_PATH}" \

--- a/execution/stdio.yaml
+++ b/execution/stdio.yaml
@@ -24,12 +24,15 @@ run:
   args:
     - -c
     - |
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
 
       # Note: OUTPUT_PATH and STDERR_PATH should now be simple filenames or relative paths
       # as they will be uploaded directly to the configured bucket location
-      ./ghost/ghost-linux-amd64 run --verbose \
+      "$GHOST_BIN" run --verbose \
         -i "${INPUT_PATH}" \
         -o "execution-output/${OUTPUT_PATH}:${OUTPUT_PATH}" \
         -e "execution-output/${STDERR_PATH}:${STDERR_PATH}" \

--- a/testing/diff.yaml
+++ b/testing/diff.yaml
@@ -23,13 +23,16 @@ run:
   args:
     - -c
     - |
-      # Make ghost executable
-      chmod +x ghost/ghost-linux-amd64
+      # Detect architecture and set ghost binary path
+      # Maps x86_64 -> amd64, aarch64 -> arm64
+      GHOST_ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+      GHOST_BIN="ghost/ghost-linux-${GHOST_ARCH}"
+      chmod +x "$GHOST_BIN"
 
       # Run ghost diff command
       # Note: OUTPUT_PATH and STDERR_PATH should now be simple filenames or relative paths
       # as they will be uploaded directly to the configured bucket location
-      ./ghost/ghost-linux-amd64 diff --verbose \
+      "$GHOST_BIN" diff --verbose \
         -i "${INPUT_PATH}" \
         -x "${EXPECTED_PATH}" \
         -o "testing-output/${OUTPUT_PATH}:${OUTPUT_PATH}" \


### PR DESCRIPTION
This pull request updates all task and test scripts to automatically detect the system architecture and select the appropriate `ghost` binary at runtime, improving compatibility across different environments. The hardcoded `ghost/ghost-linux-amd64` references are replaced with logic to determine the correct binary for either `amd64` or `arm64` architectures.

Key changes:

**Architecture-aware ghost binary selection:**
- All scripts now detect the machine architecture (`x86_64` or `aarch64`) and set the `GHOST_BIN` variable to the correct binary path. The binary is then made executable and used for subsequent commands instead of the previously hardcoded path. [[1]](diffhunk://#diff-daec3bbf874ab5f80440f615b5314265daa0398ddf10c16e87047ab91ce08176L26-R30) [[2]](diffhunk://#diff-a6ba9f0ab44b313d5f04bc79999110b76fc83b9601a1b6a5a247e17bd159ee9aL30-R34) [[3]](diffhunk://#diff-be4a804ee54a920e41fbbeb1bb2b18996fd54fca1f8cdf3c2a6661ae5037e68fL33-R37) [[4]](diffhunk://#diff-2b29f4a7b818633fd3e3cf14cd8d5cbd6d0046166e50b710a5a6656289e8ff8aL40-R44) [[5]](diffhunk://#diff-975c9a5e07bf4c14b1c74c5e1aad6df6ed8ae0ed802d03463563ec245a59c90dL33-R37) [[6]](diffhunk://#diff-e06eb772a074d30196bea833faa5b6d5a4a0979daa5c2f7c79929d4b00a2e911L27-R35) [[7]](diffhunk://#diff-a82a2f9ef4d4157fdc361ee9eda338e0e5d412ec93703119fb4c0496181d26f3L26-R35) [[8]](diffhunk://#diff-666bb81d13f8a0cf540ff0bcb50a5b7fea3a7b4d84b07a20fed1b25c6ba80d1eL304-R309)

**Consistent usage of architecture-specific ghost binary:**
- All invocations of the `ghost` command in compilation, execution, and testing YAML files now use the `$GHOST_BIN` variable, ensuring the correct binary is used regardless of architecture. [[1]](diffhunk://#diff-daec3bbf874ab5f80440f615b5314265daa0398ddf10c16e87047ab91ce08176L37-R40) [[2]](diffhunk://#diff-a6ba9f0ab44b313d5f04bc79999110b76fc83b9601a1b6a5a247e17bd159ee9aL69-R72) [[3]](diffhunk://#diff-a6ba9f0ab44b313d5f04bc79999110b76fc83b9601a1b6a5a247e17bd159ee9aL102-R105) [[4]](diffhunk://#diff-be4a804ee54a920e41fbbeb1bb2b18996fd54fca1f8cdf3c2a6661ae5037e68fL55-R58) [[5]](diffhunk://#diff-2b29f4a7b818633fd3e3cf14cd8d5cbd6d0046166e50b710a5a6656289e8ff8aL93-R96) [[6]](diffhunk://#diff-975c9a5e07bf4c14b1c74c5e1aad6df6ed8ae0ed802d03463563ec245a59c90dL53-R56) [[7]](diffhunk://#diff-e06eb772a074d30196bea833faa5b6d5a4a0979daa5c2f7c79929d4b00a2e911L27-R35) [[8]](diffhunk://#diff-a82a2f9ef4d4157fdc361ee9eda338e0e5d412ec93703119fb4c0496181d26f3L26-R35) [[9]](diffhunk://#diff-666bb81d13f8a0cf540ff0bcb50a5b7fea3a7b4d84b07a20fed1b25c6ba80d1eL304-R309)

**Documentation update:**
- The `README.md` is updated to instruct users to use the new architecture-detection logic for selecting and running the correct `ghost` binary, replacing previous hardcoded instructions.